### PR TITLE
Add capability for sub folders to acquire the carousel

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Change history
 2.2.2 (unreleased)
 ------------------
 
+- Add capability for sub folders to acquire the carousel [davismr]
+
 - Added German translation.
   [pabo3000]
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -7,3 +7,4 @@ Contributors
 * Taito Horiuchi [taito]
 * Mikko Ohtamaa [miohtama]
 * Roman Kozlovskyi [kroman0]
+* Michael Davis [davismr]

--- a/Products/Carousel/browser/folder.py
+++ b/Products/Carousel/browser/folder.py
@@ -78,6 +78,7 @@ class CarouselSettings(Persistent):
     transition_speed = 0.5
     transition_delay = 8.0
     default_page_only = True
+    sub_folder_acquire = False
     lazyload = False
     random_order = False
 
@@ -118,9 +119,10 @@ class DisplayGroup(group.Group):
 
     label = _(u'Display')
     fields = field.Fields(ICarouselSettings).select(
-        'enabled', 'default_page_only')
+        'enabled', 'default_page_only', 'sub_folder_acquire')
     fields['enabled'].widgetFactory = SingleCheckBoxFieldWidget
     fields['default_page_only'].widgetFactory = SingleCheckBoxFieldWidget
+    fields['sub_folder_acquire'].widgetFactory = SingleCheckBoxFieldWidget
 
 
 class CarouselSettingsForm(group.GroupForm, form.EditForm):

--- a/Products/Carousel/browser/viewlet.py
+++ b/Products/Carousel/browser/viewlet.py
@@ -36,6 +36,7 @@ class CarouselViewlet(ViewletBase):
         """
 
         self.available = False
+        self.acquired = False
 
         context_state = self.context.restrictedTraverse('@@plone_context_state')
         if context_state.is_structural_folder() and not context_state.is_default_page():
@@ -47,12 +48,20 @@ class CarouselViewlet(ViewletBase):
             carousel = ICarousel(folder[CAROUSEL_ID], None)
             if not carousel:
                 return
+        elif hasattr(folder, CAROUSEL_ID):
+            carousel = ICarousel(getattr(folder, CAROUSEL_ID), None)
+            self.acquired = True
+            if not carousel:
+                return
         else:
             return
 
         settings = carousel.getSettings()
 
         if not settings.enabled:
+            return
+
+        if self.acquired and not settings.sub_folder_acquire:
             return
 
         if not context_state.is_default_page():

--- a/Products/Carousel/interfaces.py
+++ b/Products/Carousel/interfaces.py
@@ -113,6 +113,12 @@ class ICarouselSettings(Interface):
         default=True,
     )
 
+    sub_folder_acquire = schema.Bool(
+        title=_(u'Acquired by sub folders'),
+        description=_(u'Allow sub folders to acquire the banner'),
+        default=False,
+    )
+
     random_order = schema.Bool(
         title=_(u'Random order'),
         description=_(u'Carousel pictures will reappear in random order on every page refresh.'),


### PR DESCRIPTION
Hi,

I've added the capability for sub folders to acquire a carousel, so you can set a carousel up for a whole site or a portion of a site.

Cheers
Michael
